### PR TITLE
fix: 다른 포트에서 API 호출 시 CORS로 인해 생기는 오류 해결

### DIFF
--- a/src/main/java/com/creddit/credditmainserver/config/SecurityConfig.java
+++ b/src/main/java/com/creddit/credditmainserver/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 
 @EnableWebSecurity
@@ -37,7 +40,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
-        http.csrf().disable()
+        http.cors().configurationSource(corsConfigurationSource())
+                .and()
+                .csrf().disable()
                 .exceptionHandling()//예외처리
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .accessDeniedHandler(jwtAccessDeniedHandler)
@@ -56,5 +61,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     }
 
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
 
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**",configuration);
+        return  source;
+    }
 }


### PR DESCRIPTION
## What does this PR do?
CORS 허용 정책을 port 3000에서도 허용하도록 하는 Bean을 생성하여 적용

## Verification Steps
### CheckList

- [ ] : port 3000에서 API가 작동하는 지
- [ ] : 다른 port에서 API가 작동하지 않는 지

### Progress
- [ ] : CORS 정책 추가

