### PR TITLE
refactor: jwt-secret을 application.yml 파일에 따로 보관

### DIFF
--- a/src/main/java/com/creddit/credditmainserver/exception/MethodArgumentNotValidException.java
+++ b/src/main/java/com/creddit/credditmainserver/exception/MethodArgumentNotValidException.java
@@ -1,0 +1,7 @@
+package com.creddit.credditmainserver.exception;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+public class MethodArgumentNotValidException {
+
+}

--- a/src/main/java/com/creddit/credditmainserver/login/jwt/TokenProvider.java
+++ b/src/main/java/com/creddit/credditmainserver/login/jwt/TokenProvider.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ser.std.ToEmptyObjectSerializer;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -30,10 +30,10 @@ public class TokenProvider{
     private static final String BEARER_TYPE = "bearer";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  //7일
-    final String secret="Y3JlZGl0LXRlYW0tc3ByaW5nLWJvb3QtanBhLW15c3FsLXByb2plY3Qtc29jaWFsLW5ldHdvcmstc2VydmljZQo=";
+
     private final Key key;
 
-    public TokenProvider(){
+    public TokenProvider(@Value("${jwt.secret}")String secret){
         byte[] keyBytes= Decoders.BASE64.decode(secret);
         this.key= Keys.hmacShaKeyFor(keyBytes);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        show-sql: true
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
@@ -20,6 +21,9 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
-server:
-  error:
-    include-stacktrace: always
+
+  jwt:
+    secret: Y3JlZGl0LXRlYW0tc3ByaW5nLWJvb3QtanBhLW15c3FsLXByb2plY3Qtc29jaWFsLW5ldHdvcmstc2VydmljZQo=
+
+
+


### PR DESCRIPTION
## What does this PR do?
TokenProvider 파일에 존재했던 jwt의 secret key를 application.yml파일에 보관하고 @Valid 어노테이션을 통해 주입
배포 시 jar파일을 수정하지 않고 설정만을 변경할 수 있어 번거로움 해소

## Verification Steps
### CheckList
- [ ] :  일반 로그인 시 jwt가 잘 발급되는지
