### PR TITLE
fix: parseClaimsJws 함수를 parseClaimJwt로 잘못 작성하여 생긴 오류 해결

### DIFF
--- a/src/main/java/com/creddit/credditmainserver/login/jwt/TokenProvider.java
+++ b/src/main/java/com/creddit/credditmainserver/login/jwt/TokenProvider.java
@@ -92,7 +92,7 @@ public class TokenProvider{
 
     public boolean validateToken(String token){
         try{//토큰 내용 검증
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
         }
         catch(io.jsonwebtoken.security.SecurityException | MalformedJwtException e){
             logger.info("잘못된 JWT 서명");


### PR DESCRIPTION
## What does this PR do?
- parseClaimsJws를 parseClaimJwt로 잘못 작성하여 AccessToken을 인자로 받았을 때 토큰 검증 불가

## Verification Steps
### CheckList

- [ ] : token을 @AuthenticaitonPrincipal 등을 사용하여 받았을 때 Principal에 null이 아닌 값이 잘 들어가는지

