### PR TITLE
feature: 소셜 로그인 중복회원 방지 기능

### DIFF
--- a/src/main/java/com/creddit/credditmainserver/service/AuthService.java
+++ b/src/main/java/com/creddit/credditmainserver/service/AuthService.java
@@ -75,6 +75,18 @@ public class AuthService {
         Member member = memberRepository.findByEmail(socialLoginRequestDto.getEmail())
                 .orElse(socialSignup(socialLoginRequestDto));
 
+        ProviderType providerType = ProviderType.LOCAL;
+        if(socialLoginRequestDto.getType().equals("kakao")){
+            providerType = ProviderType.KAKAO;
+        }
+        else if(socialLoginRequestDto.getType().equals("naver")){
+            providerType = ProviderType.NAVER;
+        }
+
+        if(member.getProviderType()==ProviderType.LOCAL || member.getProviderType()!=providerType){
+            throw new Exception("이미 회원가입된 회원입니다.");
+        }
+
         MemberRequestDto memberRequestDto = new MemberRequestDto(member.getEmail(),member.getNickname(),socialLoginRequestDto.getEmail()+key);
 
         return login(memberRequestDto);


### PR DESCRIPTION
## What does this PR do?
- 이미 다른 소셜 로그인으로 회원가입을 했거나 로컬 회원가입을 한 이메일을 소유한 유저의 로그인 방지

## Verification Steps
### CheckList
- [ ] : 로컬 회원가입을 한 이메일로 소셜 로그인을 하려할 시 예외처리가 되는지
- [ ] : 소셜 로그인 시 다른 소셜 로그인을 했던 이메일일 경우 예외처리가 되는지

### Progress
- [ ] : 소셜 로그인 시 중복 회원에 대한 분기 처리 로직 추가

