### PR TITLE
fix: 프로필 사진을 올리지 않을 시 프로필 사진이 삭제되는 것이 아닌 기존의 프로필 사진으로 유지

### DIFF
--- a/src/main/java/com/creddit/credditmainserver/api/ProfileApiController.java
+++ b/src/main/java/com/creddit/credditmainserver/api/ProfileApiController.java
@@ -50,12 +50,12 @@ public class ProfileApiController {
 
         if(!file.isEmpty()){
             image = awsS3Service.upload(file, "post");
+
         }
         else{
             image.setImgName("empty");
             image.setImgUrl("");
         }
-
         profileRequestDto.setImage(image);
         return profileService.saveProfile(id, profileRequestDto);
     }

--- a/src/main/java/com/creddit/credditmainserver/service/ProfileService.java
+++ b/src/main/java/com/creddit/credditmainserver/service/ProfileService.java
@@ -20,6 +20,12 @@ public class ProfileService {
     public ProfileResponseDto saveProfile(Long id, ProfileRequestDto profileRequestDto){
 
         Member member = findById(id);
+
+        if(profileRequestDto.getImage().getImgName().equals("empty")&& !member.getImgName().equals("") && !member.getImgName().equals("empty")){
+            profileRequestDto.getImage().setImgName(member.getImgName());
+            profileRequestDto.getImage().setImgUrl(member.getImgUrl());
+        }
+
         member.setProfile(profileRequestDto.getImage().getImgUrl(), profileRequestDto.getImage().getImgName(),profileRequestDto.getIntroduction());
         memberRepository.save(member);
 


### PR DESCRIPTION
## What does this PR do?
- 프로필 사진을 올리지 않을 시 프로필 사진이 삭제되는 것이 아닌 기존의 프로필 사진으로 유지

## Verification Steps
### CheckList
- [ ]  기존의 사진이 있고 file을 넘겨주지 않았을 시 기존의 사진으로 유지되는지
- [ ] : 기존의 사진이 없을 때 imgName이 "empty"로 뜨는지
- [ ] : 기존의 사진이 있고 file을 넘겨주었을 때 사진이 바뀌는 지
