### PR TITLE
fix: 프로필 사진 변경 기능 수정

### DIFF
--- a/src/main/java/com/creddit/credditmainserver/api/ProfileApiController.java
+++ b/src/main/java/com/creddit/credditmainserver/api/ProfileApiController.java
@@ -39,6 +39,20 @@ public class ProfileApiController {
         return profileService.getProfile(Long.parseLong(id));
     }
 
+
+
+    @PostMapping(value = "/profile/test")
+    public void test(@RequestPart(value = "image", required = false) MultipartFile file){
+        if(file == null){
+            System.out.println("file is null");
+        }
+        else if(file.isEmpty()){
+            System.out.println("file is Empty");
+        }
+
+
+    }
+
     @ApiOperation(value = "프로필 생성/수정")
     @PostMapping(value = "/profile/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ProfileResponseDto saveProfile(Principal principal,
@@ -46,18 +60,8 @@ public class ProfileApiController {
                                           @Valid @RequestPart ProfileRequestDto profileRequestDto) throws IOException {
         Long id = Long.parseLong(principal.getName());
         checkExistImgAndDelete(profileService.findById(id).getImgName());
-        Image image = new Image();
 
-        if(!file.isEmpty()){
-            image = awsS3Service.upload(file, "post");
-
-        }
-        else{
-            image.setImgName("empty");
-            image.setImgUrl("");
-        }
-        profileRequestDto.setImage(image);
-        return profileService.saveProfile(id, profileRequestDto);
+        return profileService.saveProfile(id, profileRequestDto, file);
     }
 
     private void checkExistImgAndDelete(String savedImgName) {


### PR DESCRIPTION
## What does this PR do?
 - image 키 값을 넘기되 빈 파일로 보내면 전의 프로필 사진 유지
 - image 키 값을 넘기지 않으면 기본 이미지로 변경

## Verification Steps
### CheckList
- [ ] : image 키 값을 넘기되 빈 파일로 보내면 전의 프로필 사진 유지
- [ ] : image 키 값을 넘기지 않으면 기본 이미지로 변경
- [ ]  image 카 값을 넘기되 파일도 보내면 프로필 사진 변경

